### PR TITLE
Fixed Notary version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,7 @@ task runIrohaChainAdapter(type: JavaExec) {
 
 dependencies {
     //TODO change version after D3 release
-    compile "com.github.d3ledger.notary:notary-commons:develop-SNAPSHOT"
+    compile "com.github.d3ledger.notary:notary-commons:93d89a4c58"
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     compile "com.rabbitmq:amqp-client:5.6.0"
     // unit tests


### PR DESCRIPTION
By Jitpack naming convention `compile com.github.d3ledger.notary:notary-commons:develop-SNAPSHOT` downloads the freshest version of the code from the `develop` branch. Given the fact, that the `develop` branch is changing rapidly, we must use a fixed `notary-commons` module version. It's possible by setting a particular commit from the `develop` branch.